### PR TITLE
Fix Replace removeLast() with removeAt() to avoid warnings and preven…

### DIFF
--- a/calendar/src/commonMain/kotlin/io/wojciechosak/calendar/view/CalendarView.kt
+++ b/calendar/src/commonMain/kotlin/io/wojciechosak/calendar/view/CalendarView.kt
@@ -205,7 +205,7 @@ private fun selectDate(
 		is SelectionMode.Multiply -> {
 			result.add(0, date)
 			if (result.size > mode.bufferSize) {
-				result.removeLast()
+				result.removeAt(result.lastIndex)
 			}
 		}
 


### PR DESCRIPTION
Replaced the call to removeLast() with removeAt(result.lastIndex) to prevent warnings and runtime errors when compiling with compileSdk 35 and ensure compatibility with Android 14 or lower.

![warning](https://github.com/user-attachments/assets/21a8d9d6-09db-45ac-8319-a2ffb042c4b1)

![error](https://github.com/user-attachments/assets/311d32b4-db3b-4e7d-b4e1-1a8172acc06d)

